### PR TITLE
feat: add `subscribeAndSpyOn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ it('should spy on Observable errors', () => {
 });
 ```
 
-#### Quick Usage with `subscribeAndSpyOn(observable)`
+## Quick Usage with `subscribeAndSpyOn(observable)`
 
-You can also create an `ObserverSpy` and immediately subscribe to an observable with this simple helper function. Observer spies generated that way will provide an additional `unsubscribe()` method that you might want to call if your source observable does not complete or does not get terminated by an error while testing.
+You can also create an `ObserverSpy` and immediately subscribe to an observable with this simple helper function.
+Observer spies generated that way will provide an additional `unsubscribe()` method that you might want to call
+if your source observable does not complete or does not get terminated by an error while testing.
 
 **Example:**
 
@@ -148,13 +150,15 @@ import { subscribeAndSpyOn } from '@hirez_io/observer-spy';
 it('should immediately subscribe and spy on Observable ', () => {
   const fakeObservable = of('first', 'second', 'third');
 
-  // shorthand usage
-  expect(subscribeAndSpyOn(fakeObservable).getFirstValue()).toEqual('first');
-
-  // or get the observer spy
+  // get an "ObserverSpyWithSubscription"
   const observerSpy = subscribeAndSpyOn(fakeObservable);
   // and optionally unsubscribe
   observerSpy.unsubscribe();
+
+  expect(observerSpy.getFirstValue()).toEqual('first');
+
+  // or use the shorthand version:
+  expect(subscribeAndSpyOn(fakeObservable).getFirstValue()).toEqual('first');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A simple little class and a helper function that help make Observable testing a 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://img.shields.io/codecov/c/github/hirezio/observer-spy.svg)](https://codecov.io/gh/hirezio/observer-spy) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <div align="center">
   <a href="http://testangular.com/?utm_source=github&utm_medium=link&utm_campaign=observer-spy">
@@ -132,6 +133,28 @@ it('should spy on Observable errors', () => {
   expect(observerSpy.receivedError()).toBe(true);
 
   expect(observerSpy.getError()).toEqual('FAKE ERROR');
+});
+```
+
+#### Quick Usage with `subscribeAndSpyOn(observable)`
+
+You can also create an `ObserverSpy` and immediately subscribe to an observable with this simple helper function. Observer spies generated that way will provide an additional `unsubscribe()` method that you might want to call if your source observable does not complete or does not get terminated by an error while testing.
+
+**Example:**
+
+```js
+import { subscribeAndSpyOn } from '@hirez_io/observer-spy';
+
+it('should immediately subscribe and spy on Observable ', () => {
+  const fakeObservable = of('first', 'second', 'third');
+
+  // shorthand usage
+  expect(subscribeAndSpyOn(fakeObservable).getFirstValue()).toEqual('first');
+
+  // or get the observer spy
+  const observerSpy = subscribeAndSpyOn(fakeObservable);
+  // and optionally unsubscribe
+  observerSpy.unsubscribe();
 });
 ```
 
@@ -314,6 +337,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { ObserverSpy } from './observer-spy';
-export { subscribeAndSpyOn } from './subscribe-and-spy-on';
+export { subscribeAndSpyOn, ObserverSpyWithSubscription } from './subscribe-and-spy-on';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { ObserverSpy } from './observer-spy';
+export { subscribeAndSpyOn } from './subscribe-and-spy-on';

--- a/src/subscribe-and-spy-on.spec.ts
+++ b/src/subscribe-and-spy-on.spec.ts
@@ -1,6 +1,6 @@
-import { subscribeAndSpyOn } from './subscribe-and-spy-on';
 import { Observable, Subject } from 'rxjs';
 import { ObserverSpy } from './observer-spy';
+import { subscribeAndSpyOn } from './subscribe-and-spy-on';
 
 describe('subscribeAndSpyOn', () => {
   it('should return an ObserverSpy with unsubscribe method', () => {

--- a/src/subscribe-and-spy-on.spec.ts
+++ b/src/subscribe-and-spy-on.spec.ts
@@ -1,0 +1,28 @@
+import { subscribeAndSpyOn } from './subscribe-and-spy-on';
+import { Observable, Subject } from 'rxjs';
+import { ObserverSpy } from './observer-spy';
+
+describe('subscribeAndSpyOn', () => {
+  it('should return an ObserverSpy with unsubscribe method', () => {
+    const observerSpy = subscribeAndSpyOn(new Observable());
+
+    expect(observerSpy).toBeInstanceOf(ObserverSpy);
+    expect(observerSpy.unsubscribe).toBeInstanceOf(Function);
+  });
+
+  it('should match with given subscription points', () => {
+    const fakeSubject = new Subject<number>();
+    fakeSubject.next(1);
+    const observerSpy = subscribeAndSpyOn(fakeSubject.asObservable());
+
+    fakeSubject.next(2);
+    fakeSubject.next(3);
+    observerSpy.unsubscribe();
+
+    fakeSubject.next(4);
+    fakeSubject.complete();
+
+    expect(observerSpy.getFirstValue()).toBe(2);
+    expect(observerSpy.getLastValue()).toBe(3);
+  });
+});

--- a/src/subscribe-and-spy-on.spec.ts
+++ b/src/subscribe-and-spy-on.spec.ts
@@ -1,15 +1,7 @@
-import { Observable, Subject } from 'rxjs';
-import { ObserverSpy } from './observer-spy';
+import { Subject } from 'rxjs';
 import { subscribeAndSpyOn } from './subscribe-and-spy-on';
 
 describe('subscribeAndSpyOn', () => {
-  it('should return an ObserverSpy with unsubscribe method', () => {
-    const observerSpy = subscribeAndSpyOn(new Observable());
-
-    expect(observerSpy).toBeInstanceOf(ObserverSpy);
-    expect(observerSpy.unsubscribe).toBeInstanceOf(Function);
-  });
-
   it('should match with given subscription points', () => {
     const fakeSubject = new Subject<number>();
     fakeSubject.next(1);

--- a/src/subscribe-and-spy-on.ts
+++ b/src/subscribe-and-spy-on.ts
@@ -5,7 +5,7 @@ export function subscribeAndSpyOn<T>(observableUnderTest: Observable<T>) {
   return new ObserverSpyWithSubscription(observableUnderTest);
 }
 
-export class ObserverSpyWithSubscription<T> extends ObserverSpy<T> {
+class ObserverSpyWithSubscription<T> extends ObserverSpy<T> {
   public subscription = new Subscription();
 
   constructor(observableUnderTest: Observable<T>) {

--- a/src/subscribe-and-spy-on.ts
+++ b/src/subscribe-and-spy-on.ts
@@ -1,0 +1,19 @@
+import { Observable, Subscription } from 'rxjs';
+import { ObserverSpy } from './observer-spy';
+
+export function subscribeAndSpyOn<T>(observableUnderTest: Observable<T>) {
+  return new ObserverSpyWithSubscription(observableUnderTest);
+}
+
+export class ObserverSpyWithSubscription<T> extends ObserverSpy<T> {
+  public subscription = new Subscription();
+
+  constructor(observableUnderTest: Observable<T>) {
+    super();
+    this.subscription.add(observableUnderTest.subscribe(this));
+  }
+
+  unsubscribe(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/subscribe-and-spy-on.ts
+++ b/src/subscribe-and-spy-on.ts
@@ -5,7 +5,7 @@ export function subscribeAndSpyOn<T>(observableUnderTest: Observable<T>) {
   return new ObserverSpyWithSubscription(observableUnderTest);
 }
 
-class ObserverSpyWithSubscription<T> extends ObserverSpy<T> {
+export class ObserverSpyWithSubscription<T> extends ObserverSpy<T> {
   public subscription = new Subscription();
 
   constructor(observableUnderTest: Observable<T>) {


### PR DESCRIPTION
A first proposal to resolve #7 .
As opposed to my [first approach](https://github.com/hirezio/observer-spy/issues/7#issue-638638278), where I tried to hide subscriptions altogether, I thought it would be more consistent with sticking to subscription terminology. The implementation of this turned out to be way more straight forward. I also wanted to discuss this first before updating the docs.
Let me know what you think about it!