### PR TITLE
fix: add missing `fakeTime` export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { ObserverSpy } from './observer-spy';
+export { fakeTime } from './fake-time';


### PR DESCRIPTION
I noticed that the export of `fakeTime` seems to be missing.
Hope you don't mind that I didn't open an issue just for this.