### PR TITLE
feat(observer-spy): add spyOn() utility and improved tests

### DIFF
--- a/src/observer-spy.factory.spec.ts
+++ b/src/observer-spy.factory.spec.ts
@@ -1,0 +1,89 @@
+import { Observable, of, throwError, Subscription, from } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { delay } from 'rxjs/operators';
+
+import { spyOn, SpyUtils } from './observer-spy.factory';
+
+describe('Observer-Spy Factory', () => {
+  const list = ['first', 'second', 'third'];
+
+  describe(`build a spy on 3-value stream`, () => {
+    it('should set `called.next` to true', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(['first', 'second', 'third']));
+
+      disconnect();
+      expect(oSpy.state.called.next).toBe(true);
+    });
+
+    it('should be able to return the correct first value', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.readFirst()).toEqual(list[0]);
+    });
+
+    it('should be able to return the correct value at any index', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.values[1]).toEqual(list[1]);
+    });
+
+    it('should be able to return the correct last value', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.readLast()).toEqual(list[2]);
+    });
+
+    it('should know whether it got a "complete" notification', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.state.called.complete).toBe(true);
+    });
+  });
+  describe('supports subscription cleanup during `disconnect()`', () => {
+    it('should detect subscriptions', () => {
+      const [, disconnect] = spyOn<string>(from(list));
+      const isWatching = SpyUtils.hasSpys();
+
+      expect(isWatching).toBe(true);
+      disconnect();
+    });
+
+    it('should cleanup with `disconnect()`', () => {
+      const [, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+
+      const isWatching = SpyUtils.hasSpys();
+      expect(isWatching).toBe(false);
+    });
+  });
+
+  describe('supports globa subscription cleanup without `disconnect()`', () => {
+    afterEach(() => {
+      expect(SpyUtils.hasSpys()).toBe(true);
+      SpyUtils.disposeAll();
+      expect(SpyUtils.hasSpys()).toBe(false);
+    });
+    it('should detect subscriptions', () => {
+      let completed = false;
+      const onCompletion = () => (completed = true);
+
+      spyOn<string>(from(['1st', '2nd', '3rd']));
+      spyOn<string>(from(['4th', '5th', '6th']), onCompletion);
+
+      const isWatching = SpyUtils.hasSpys();
+      expect(isWatching).toBe(true);
+      expect(completed).toBe(true);
+    });
+  });
+});
+
+function makeTestScheduler() {
+  return new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+}

--- a/src/observer-spy.factory.ts
+++ b/src/observer-spy.factory.ts
@@ -1,0 +1,75 @@
+import { Observer, Observable, Subscription } from 'rxjs';
+import { ObserverSpy, CompletionCallback } from './observer-spy';
+
+/**
+ * Define Tuple reponse from spyOn() calls
+ */
+export type SpyOnResults<T> = [ObserverSpy<T>, () => void];
+
+/**
+ * Internal registory of active spy instances
+ */
+let subscriptions: SpyOnResults<any>[] = [];
+
+/**
+ * Internal util function to remove a spy from the global watch list
+ */
+function removeSpyFromWatchList(target: ObserverSpy<any>) {
+  // Rebuild watch list WITHOUT the target spy instance
+  subscriptions = subscriptions.reduce(
+    (buffer: SpyOnResults<any>[], item: SpyOnResults<any>) => {
+      const [spy] = item;
+      if (target !== spy) {
+        buffer.push(item);
+      }
+      return buffer;
+    },
+    []
+  );
+}
+
+export const SpyUtils = {
+  /**
+   * Freeze all spys and dispose of any subscriptions
+   * Used with tests `afterEach(() => disposeAllSpys())`
+   */
+  disposeAll() {
+    [...subscriptions].map(([spy, dispose]) => {
+      spy.freeze(true);
+      dispose();
+    });
+
+    subscriptions = [];
+  },
+
+  /**
+   * Allows external world to check for existing subscriptions
+   */
+  hasSpys(): boolean {
+    return subscriptions.length > 0;
+  },
+};
+
+/**
+ * spyOn(): simplify use of ObserverSpy by black-box'ing the
+ * ObserverSpy construction and disposal details.
+ *
+ * @param source Observable<T>
+ * @param completionCallback [optional] Callback function invoked when the source stream completes
+ */
+export function spyOn<T>(
+  source: Observable<T>,
+  completionCallback?: CompletionCallback
+): SpyOnResults<T> {
+  const spy = new ObserverSpy<T>(completionCallback);
+  const subscription = source.subscribe(spy);
+  const dispose = () => {
+    subscription.unsubscribe();
+    removeSpyFromWatchList(spy);
+  };
+  const results: SpyOnResults<T> = [spy, dispose];
+
+  subscriptions.push(results);
+
+  return results;
+}


### PR DESCRIPTION
Enable developers to easily spy on Observables and supports auto-unsubscribe on all spies:

*  Use `spyOn(<observable>, <completionCallback>)`
*  Use `SpyUtils.disposeAll()` to clean up in `afterEach()` tests

BREAKING CHANGE:

Revised ObserverSpy API with better support for implicit getters and prevention of state mutations. Uses Tuples to return spy instance(s) and information:

```ts
ObserverSpy<T> implements Observer {
  values: T[];                  // implicit getter
  hasValues: boolean;   // implicit getter
  isComplete: boolean; // implicit getter
  state: ObserverState; // implicit getter

  readFirst(): T;
  readLast(): T;
  freeze();
}
```
