### PR TITLE
feat(observer-spy): add spyOn() utility and improved tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# @hirez_io/observer-spy 👀💪
-
-A simple little class that helps making Observable testing a breeze
+# @hirez_io/observer-spy
 
 [![npm version](https://img.shields.io/npm/v/@hirez_io/observer-spy.svg?style=flat-square)](https://www.npmjs.org/package/@hirez_io/observer-spy)
 [![npm downloads](https://img.shields.io/npm/dm/@hirez_io/observer-spy.svg?style=flat-square)](http://npm-stat.com/charts.html?package=@hirez_io/observer-spy&from=2017-07-26)
@@ -8,238 +6,254 @@ A simple little class that helps making Observable testing a breeze
 [![codecov](https://img.shields.io/codecov/c/github/hirezio/observer-spy.svg)](https://codecov.io/gh/hirezio/observer-spy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
+## Installation
+
+```
+npm install -D @hirez_io/observer-spy
+```
+
+or
+
+```
+yarn add -D @hirez_io/observer-spy
+```
+
+<br/>
+
+## Challenges
+
+Testing RxJS observables is unusually hard, especially when testing advanced use cases. This library:
+
+- Makes it **easy** to understand
+- **Reduces** the complexity
+- Makes **testing** advanced observables easy
+
+[Marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) offer very powerful testing solutions. Unfortunately marble tests are conceptually very complicated to learn and to reason about. Marble tests <u>are not suitable</u> for day-to-day testing within most developer testing.
+
+Why are Marble Tests difficult?
+
+You need to learn and understand `cold` and `hot` observables, `schedulers` and to learn a new syntax just to test a simple observable chain. More complex observable chains tests gets even harder to read.
+
+## Solution
+
+The **Observer-Spy** library was created to present a viable alternative to Marble Tests. An _alternative_ that is cleaner, easier to understand, and super-easy to use. **Observer-Spy** makes RxJS testing easy! 👀💪
+
+Why are Observer **Spy(s)** better?
+
+You generally want to test the <u>outcome of your action</u> instead of implementation details [like how many frames were between each value].
+
+For most production apps use cases, testing the **received values** is the requirement. Most of the time, `it()` should be sufficient to prove whether the expected RxJS stream outcome is valid or not.
+
+<br/>
+
+## Usage
+
+<br/>
+
+#### `spyOn()`
+
+In order to test observables, you can use the `spyOn(<observable>, completionCallback)` function to auto-subscribe to the stream and "record" all the values that stream observable emits. `spyOn()` even returns a `dispose` function to easily unsubscribe from the stream.
+
+> You can also spy on the `error` or `complete` states of the observer.
+
+```ts
+  const [spy, dispose] = spyOn(<observable>);
+```
+
+#### Using `SpyUtils`
+
+```ts
+afterEach(() => {
+  SpyUtils.disposeAll();
+});
+```
+
+Now developers can easily batch unsubscribe all spys in their tests: using `SpyUtils.disposeAll()`.
+
+<br/>
+
+##### **Example:**
+
+```js
+import { Observable, from } from 'rxjs';
+import { spyOn, SpyUtils } from '@hirez_io/observer-spy';
+
+describe('Using spyOn() features', () => {
+  afterEach(() => SpyUtils.disposeAll()); // unsubscribe all spys
+
+  it('should spy on Observable values', () => {
+    const list = ['1st', '2nd', '3rd'];
+    const source$: Observable<string> = from(list);
+    const optionalCallback = (spy1) => {
+      expect(spy1.state.called.complete).toBe(true);
+    };
+    const [spy, dispose, , values] = spyOn(source$, optionalCallback);
+
+    expect(spy.values).toEqual(list);
+    expect(spy.values.length).toEqual(list.length);
+
+    expect(spy.readFirst()).toEqual('1st');
+    expect(spy.values(1)).toEqual(list[1]);
+    expect(spy.readLast()).toEqual('3rd');
+
+    expect(spy.state.called.next).toBe(true);
+    expect(spy.state.called.complete).toBe(true);
+
+    dispose(); // can directly dispose of spy connection
+  });
+
+  it('should spy on Observable errors', () => {
+    const stream$ = throwError('FAKE ERROR');
+    const [spy] = spyOn(stream$);
+
+    expect(spy.state.called.error).toBe(true);
+    expect(spy.state.errorValue).toEqual('FAKE ERROR');
+  });
+});
+```
+
+<br/>
+<br/>
+
+# Testing Sync Logic
+
+### ▶ Synchronous RxJS
+
+RxJS - without delaying operators or async execution contexts - will run synchronously. This is the simplest use case; where our `it()` does not need any special asynchronous plugins.
+
+```ts
+it('should set `called.next` to true', () => {
+  const [spy, disconnect] = spyOn(from(['first', 'second', 'third']));
+  expect(spy.values.length).toBe(3);
+});
+```
+
+<br/>
+<br/>
+
+# Testing Async Logic
+
+General Rules:
+
+- If you are using Promise(s), just use the test callback `done()`.
+- If you are using any RxJS operators like `delay` or `timeout` in your tests, you should use the `fakeTime` utility function and call `flush()` to simulate the passage of time;
+
+[![image](https://user-images.githubusercontent.com/210413/85336618-83f92180-b4a4-11ea-800d-6bb275eeda45.png)](#-for-time-based-rxjs-code-timeouts--intervals--animations---use-faketime)
+
+<br/>
+
+### ▶ Async Promises
+
+Since Promise(s) are [MicroTasks](https://javascript.info/microtask-queue), we should consider them to resolve asynchronously.
+
+For code using either _Promise(s)_ **without timeouts or intervals**, just use `it('should ....', (done) => {});`.
+
+Developers will call the `done()` function inside the optional `onComplete()` callback option in the `spyOn(<observable>, <callback>)` function:
+
+```ts
+// ... other imports
+import { spyOn } from '@hirez_io/observer-spy';
+
+it('should work with promises', (done) => {
+  const EVENT = 'fake data';
+  const fakeService = { getData: () => Promise.resolve(EVENT) };
+  const http$ = of('').pipe(switchMap(() => fakeService.getData()));
+
+  spyOn(http$, (spy) => {
+    expect(spy.readLast()).toEqual(EVENT);
+    done();
+  });
+});
+```
+
+### ▶ Async RxJS code
+
+RxJS code that has time-based logic (e.g using timeouts / intervals / animations) will emit asynchronously. And RxJS streams constructed from HTTP REST calls will emit asynchronously. `fakeTime()` is a a custom utility function perfect for most of these use-cases.
+
+`fakeTime()` does the following things:
+
+1. Changes the RxJS `AsyncScheduler` delegate to use `VirtualTimeScheduler` and use "virtual time".
+2. Passes a `flush` function you can call to `flush()` when you want to virtually pass time forward.
+3. Works well with `done` if you pass it as the second parameter (instead of the first)
+
+Now - with our virtual time =- your tests are easy:
+
+```ts
+import { from } from 'rxjs';
+import { spyOn, SpyUtils, fakeTime } from '@hirez_io/observer-spy';
+
+describe('spyOn with fakeTime', () => {
+  afterEach(() => SpyUtils.disposeAll());
+
+  it(
+    'should handle delays with a virtual scheduler',
+    fakeTime((flush) => {
+      const VALUES = ['first', 'second', 'third'];
+      const delayed$ = from(VALUES).pipe(delay(20000));
+      const [spy] = spyOn(delayed$);
+
+      flush();
+
+      expect(spy.values).toEqual(VALUES);
+    })
+  );
+
+  it(
+    'should handle `done()` functionality as well',
+    fakeTime((flush, done) => {
+      const VALUES = ['first', 'second', 'third'];
+      const delayed$ = from(VALUES).pipe(delay(20000));
+      const [spy1] = spyOn(delayed$, (spy) => {
+        expect(spy1.values).toEqual(spy.values);
+        done();
+      });
+
+      flush();
+    })
+  );
+});
+```
+
+### ▶ Async RxJS code + _Angular_
+
+With Angular, you can control time in a much more versatile way. Just use `fakeAsync` (and `tick` if you need it):
+
+```ts
+// ... other imports
+import { spyOn } from '@hirez_io/observer-spy';
+import { fakeAsync, tick } from '@angular/core/testing';
+
+it('should test Angular code with delay', fakeAsync(() => {
+  const EVENT = 'fake value';
+  const delayed$ = of(EVENT).pipe(delay(1000));
+  const [spy, dispose] = spyOn(delayed$);
+
+  tick(1000);
+  dispose();
+
+  expect(spy.readLast()).toEqual(EVENT);
+}));
+```
+
+### ▶ For _AJAX_ calls
+
+Asynchronous REST calls (using axios, http, fetch, etc.) should not be tested in a unit / micro test... Test those in an integration test! 😜
+
+<br/>
+
+## Wanna learn more?
+
+In the online course ["Testing In Action"](http://testangular.com/?utm_source=github&utm_medium=link&utm_campaign=observer-spy), @shai_reznik will go over all the differences and show you how to use this library to test stuff like `switchMap`, `interval` etc...
+
+<br/>
+
 <div align="center">
   <a href="http://testangular.com/?utm_source=github&utm_medium=link&utm_campaign=observer-spy">
-    <img src="for-readme/test-angular.jpg"
+    <img src="for-readme/test-angular.jpg" href="http://testangular.com/?utm_source=github&utm_medium=link&utm_campaign=observer-spy"
       alt="TestAngular.com - Free Angular Testing Workshop - The Roadmap to Angular Testing Mastery"
       width="600"
     />
   </a>
 </div>
 
-## What's the problem?
-
-Testing RxJS observables is usually hard, especially when testing advanced use cases.
-
-This library:
-
-✅ **Is easy to understand**
-
-✅ **Reduces the complexity**
-
-✅ **Makes testing advanced observables easy**
-
-## Installation
-
-```
-yarn add -D @hirez_io/observer-spy
-```
-
-or
-
-```
-npm install -D @hirez_io/observer-spy
-```
-
-## Why not marble testing?
-
-[Marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/internal-marble-tests) are very powerful, but at the same time very complicated to learn and to reason about (IMO). 
-
-You need to learn and understand `cold` and `hot` observables, `schedulers` and to learn a new syntax just to test a simple observable chain.
-
-More complex observable chains tests gets even harder to read. 
-
-So that's why this library was created - to present another alternative to marble tests that I believe is more cleaner and easier to understand and implement. 
-
-### How observer spies are cleaner?
-
-You generally want to test the outcome of your action, not implementation details like exactly how many frames were between each value. 
-
-The order of recieved values represents the desired outcome for most production apps use cases.
-
-Most of the time, if enough (virtual) time passes until the expectation in my test, it should be sufficient to prove whether the expected outcome is valid or not.
-
-
-
-## Usage
-
-#### `new ObserverSpy()`
-
-In order to test observables, you can use an `ObserverSpy` instance to "record" all the messages a source observable emits and to get them as an array.
-
-You can also spy on the `error` or `complete` states of the observer.
-
-**Example:**
-
-```js
-// ... other imports
-import { ObserverSpy } from '@hirez_io/observer-spy';
-
-it('should spy on Observable values', () => {
-  const observerSpy = new ObserverSpy();
-  const fakeValues = ['first', 'second', 'third'];
-  const fakeObservable = of(...fakeValues);
-
-  const subscription = fakeObservable.subscribe(observerSpy);
-
-  // DO SOME LOGIC HERE
-
-  // unsubscribing is optional, it's good for stopping intervals etc
-  subscription.unsubscribe();
-
-  expect(observerSpy.receivedNext()).toBe(true);
-
-  expect(observerSpy.getValues()).toEqual(fakeValues);
-
-  expect(observerSpy.getValuesLength()).toEqual(3);
-
-  expect(observerSpy.getFirstValue()).toEqual('first');
-
-  expect(observerSpy.getValueAt(1)).toEqual('second');
-
-  expect(observerSpy.getLastValue()).toEqual('third');
-
-  expect(observerSpy.receivedComplete()).toBe(true);
-
-  observerSpy.onComplete(() => {
-    expect(observerSpy.receivedComplete()).toBe(true);
-  }));
-});
-
-it('should spy on Observable errors', () => {
-  const observerSpy = new ObserverSpy();
-
-  const fakeObservable = throwError('FAKE ERROR');
-
-  fakeObservable.subscribe(observerSpy);
-
-  expect(observerSpy.receivedError()).toBe(true);
-
-  expect(observerSpy.getError()).toEqual('FAKE ERROR');
-});
-```
-
-# Testing Async Observables
-
-#### `it('should do something', fakeTime((flush) => {  ... flush(); });`
-
-You can use the `fakeTime` utility function and call `flush()` to simulate the passage of time, if you have any async operators like `delay` or `timeout` in your tests, 
-
-### [SEE AN EXAMPLE HERE](#-for-time-based-rxjs-code-timeouts--intervals--animations---use-faketime)
-
----
-
-## Now, let's see some use cases and their solutions:
-
-### ▶ For _Angular_ code - just use `fakeAsync`
-
-You can control time in a much more versitle way and to clear the microtasks queue (for promises) without using the `done()` which is much more convenient. 
-
-So just use `fakeAsync` (and `tick` if you need it)
-
-Example:
-
-```js
-// ... other imports
-import { ObserverSpy } from '@hirez_io/observer-spy';
-import { fakeAsync, tick } from '@angular/core/testing';
-
-it('should test Angular code with delay', fakeAsync(() => {
-  const observerSpy = new ObserverSpy();
-
-  const fakeObservable = of('fake value').pipe(delay(1000));
-
-  const sub = fakeObservable.subscribe(observerSpy);
-
-  tick(1000);
-
-  sub.unsubscribe();
-
-  expect(observerSpy.getLastValue()).toEqual('fake value');
-}));
-```
-
-### ▶ For only _promises_ (no timeouts / intervals) - just use `done`
-
-You can use the `onComplete` method of the ObserverSpy to run the expectation and call `done` 
-
-Example:
-
-```js
-// ... other imports
-import { ObserverSpy } from '@hirez_io/observer-spy';
-
-it('should work with promises', (done) => {
-  const observerSpy: ObserverSpy<string> = new ObserverSpy();
-
-  const fakeService = {
-    getData() {
-      return Promise.resolve('fake data');
-    },
-  };
-  const fakeObservable = of('').pipe(switchMap(() => fakeService.getData()));
-
-  fakeObservable.subscribe(observerSpy);
-
-  observerSpy.onComplete(() => {
-    expect(observerSpy.getLastValue()).toEqual('fake data');
-    done();
-  });
-});
-```
-
-### ▶ For _time based_ rxjs code (timeouts / intervals / animations) - use `fakeTime`
-
-`fakeTime` is a utility function that wraps the test callback.
-
-It does the following things:
-
-1. Changes the `AsyncScheduler` delegate to use `VirtualTimeScheduler` (which gives you the ability to use "virtual time" instead of having long tests.
-2. Passes a `flush` function you can call to `flush()` when you want to virtually pass time forward.
-3. Works well with `done` if you pass it as the second parameter (instead of the first)
-
-Example:
-
-```js
-// ... other imports
-import { ObserverSpy, fakeTime } from '@hirez_io/observer-spy';
-
-it(
-  'should handle delays with a virtual scheduler', fakeTime((flush) => {
-    const VALUES = ['first', 'second', 'third'];
-    const observerSpy: ObserverSpy<string> = new ObserverSpy();
-    const delayedObservable: Observable<string> = of(...VALUES).pipe(delay(20000));
-
-    const sub = delayedObservable.subscribe(observerSpy);
-    flush();
-    sub.unsubscribe();
-
-    expect(observerSpy.getValues()).toEqual(VALUES);
-  })
-);
-
-it(
-  'should handle be able to deal with done functionality as well', fakeTime((flush, done) => {
-    const VALUES = ['first', 'second', 'third'];
-    const observerSpy: ObserverSpy<string> = new ObserverSpy();
-    const delayedObservable: Observable<string> = of(...VALUES).pipe(delay(20000));
-
-    const sub = delayedObservable.subscribe(observerSpy);
-    flush();
-    sub.unsubscribe();
-
-    observerSpy.onComplete(() => {
-      expect(observerSpy.getValues()).toEqual(VALUES);
-      done();
-    });
-  })
-);
-```
-
-### ▶ For _ajax_ calls (http) - they shouldn't be tested in a unit / micro test... 😜
-
-Yeah. Test those in an integration test
-
-## Wanna learn more?
-
-In my [class testing In action course](http://testangular.com/?utm_source=github&utm_medium=link&utm_campaign=observer-spy) I go over all the differences and show you how to use this library to test stuff like `switchMap`, `interval` etc...
+<br/>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { spyOn, SpyUtils } from './spy-on';
 export { ObserverSpy } from './observer-spy';

--- a/src/observer-spy.spec.ts
+++ b/src/observer-spy.spec.ts
@@ -1,126 +1,125 @@
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, throwError, Subscription, from } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
 import { delay } from 'rxjs/operators';
-import { ObserverSpy } from './observer-spy';
 
-describe('ObserverSpy', () => {
-  describe(`GIVEN observable emits 3 values and completes
-            WHEN subscribing`, () => {
-    function getObservableWith3Values() {
-      const observerSpy: ObserverSpy<string> = new ObserverSpy();
-      const fakeValues: any[] = ['first', 'second', 'third'];
-      const fakeObservable: Observable<string> = of(...fakeValues);
+import { ObserverSpy, CompletionCallback } from './observer-spy';
 
-      return {
-        observerSpy,
-        fakeValues,
-        fakeObservable,
-      };
-    }
-
+describe('Observer-Spy', () => {
+  describe(`given an observable emits 3 values and completes`, () => {
     it('should set receivedNext to true', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
+      const [oSpy, , , disconnect] = makeObservableAndSpy();
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.receivedNext()).toBe(true);
+      disconnect();
+      expect(oSpy.state.called.next).toBe(true);
     });
 
     it('should return the right values', () => {
-      const { observerSpy, fakeObservable, fakeValues } = getObservableWith3Values();
+      const [oSpy, , list, disconnect] = makeObservableAndSpy();
+      disconnect(); // disconnect and freeze spy
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getValues()).toEqual(fakeValues);
-    });
-
-    it('should return the values length of 3', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
-
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getValuesLength()).toEqual(3);
+      expect(oSpy.values).toEqual(list);
     });
 
     it('should be able to return the correct first value', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
+      const [oSpy, , list, disconnect] = makeObservableAndSpy();
+      disconnect();
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getFirstValue()).toEqual('first');
+      expect(oSpy.readFirst()).toEqual(list[0]);
     });
 
     it('should be able to return the correct value at any index', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
+      const [oSpy, , list, disconnect] = makeObservableAndSpy();
+      disconnect();
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getValueAt(1)).toEqual('second');
+      expect(oSpy.values[1]).toEqual(list[1]);
     });
 
     it('should be able to return the correct last value', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
+      const [oSpy, , list, disconnect] = makeObservableAndSpy();
+      disconnect();
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getLastValue()).toEqual('third');
+      expect(oSpy.readLast()).toEqual(list[2]);
     });
 
     it('should know whether it got a "complete" notification', () => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
+      const [oSpy, , , disconnect] = makeObservableAndSpy();
+      disconnect();
 
-      fakeObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.receivedComplete()).toBe(true);
+      expect(oSpy.state.called.complete).toBe(true);
     });
 
     it('should be able to call a callback when it completes synchronously ', (done) => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
-
-      fakeObservable.subscribe(observerSpy);
-
-      observerSpy.onComplete(() => {
-        expect(observerSpy.receivedComplete()).toBe(true);
+      const onComplete: CompletionCallback = (spy: ObserverSpy<any>) => {
+        expect(spy.state.called.complete).toBe(true);
         done();
-      });
+      };
+
+      makeObservableAndSpy(onComplete);
     });
 
     it('should be able to call a callback when it completes asynchronously', (done) => {
-      const { observerSpy, fakeObservable } = getObservableWith3Values();
-
-      fakeObservable.pipe(delay(1)).subscribe(observerSpy);
-
-      observerSpy.onComplete(() => {
-        expect(observerSpy.receivedComplete()).toBe(true);
+      const autoSubscribe = false;
+      const onComplete: CompletionCallback = (spy: ObserverSpy<any>) => {
+        expect(spy.state.called.complete).toBe(true);
         done();
+      };
+
+      makeTestScheduler().run(({ flush }) => {
+        const [oSpy, source$] = makeObservableAndSpy(onComplete, autoSubscribe);
+        const subscription = source$.pipe(delay(1)).subscribe(oSpy);
+
+        flush();
+        subscription.unsubscribe();
       });
     });
   });
 
-  describe('GIVEN observable throws WHEN subscribing', () => {
-    function getThrowingObservable() {
-      const observerSpy: ObserverSpy<string> = new ObserverSpy();
+  describe('with an observable that throws Error', () => {
+    function getThrowingObservable(): [ObserverSpy<string>, Observable<string>] {
+      const oSpy: ObserverSpy<string> = new ObserverSpy();
       const throwingObservable: Observable<string> = throwError('FAKE ERROR');
 
-      return {
-        observerSpy,
-        throwingObservable,
-      };
+      return [oSpy, throwingObservable];
     }
 
     it('should know whether it got an "error" notification', () => {
-      const { observerSpy, throwingObservable } = getThrowingObservable();
+      const [oSpy, source$] = getThrowingObservable();
 
-      throwingObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.receivedError()).toBe(true);
+      source$.subscribe(oSpy).unsubscribe();
+      expect(oSpy.state.called.error).toBe(true);
     });
 
     it('should return the error object it received', () => {
-      const { observerSpy, throwingObservable } = getThrowingObservable();
+      const [oSpy, source$] = getThrowingObservable();
 
-      throwingObservable.subscribe(observerSpy).unsubscribe();
-
-      expect(observerSpy.getError()).toEqual('FAKE ERROR');
+      source$.subscribe(oSpy).unsubscribe();
+      expect(oSpy.state.errorValue).toEqual('FAKE ERROR');
     });
   });
 });
+
+type Testables = [ObserverSpy<string>, Observable<string>, string[], () => void];
+
+function makeObservableAndSpy(
+  onComplete?: CompletionCallback,
+  autoSubscribe = true
+): Testables {
+  let subscription: Subscription;
+
+  const oSpy: ObserverSpy<string> = new ObserverSpy(onComplete);
+  const list: any[] = ['first', 'second', 'third'];
+  const source$: Observable<string> = from(list);
+  const dispose = () => subscription && subscription.unsubscribe();
+
+  if (autoSubscribe) {
+    subscription = source$.subscribe(oSpy);
+  }
+
+  return [oSpy, source$, list, dispose];
+}
+
+function makeTestScheduler() {
+  return new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+}

--- a/src/spy-on.spec.ts
+++ b/src/spy-on.spec.ts
@@ -1,0 +1,114 @@
+import { ObserverSpy } from './observer-spy';
+import { from } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+import { spyOn, SpyUtils } from './spy-on';
+import { fakeTime } from './fake-time';
+
+describe('spy-on', () => {
+  const list = ['first', 'second', 'third'];
+
+  describe(`build a spy on 3-value stream`, () => {
+    it('should set `called.next` to true', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(['first', 'second', 'third']));
+
+      disconnect();
+      expect(oSpy.state.called.next).toBe(true);
+    });
+
+    it('should be able to return the correct first value', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.readFirst()).toEqual(list[0]);
+    });
+
+    it('should be able to return the correct value at any index', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.values[1]).toEqual(list[1]);
+    });
+
+    it('should be able to return the correct last value', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.readLast()).toEqual(list[2]);
+    });
+
+    it('should know whether it got a "complete" notification', () => {
+      const [oSpy, disconnect] = spyOn<string>(from(list));
+
+      disconnect();
+      expect(oSpy.state.called.complete).toBe(true);
+    });
+  });
+  describe('supports subscription cleanup during `disconnect()`', () => {
+    it('should detect subscriptions', () => {
+      const [, disconnect] = spyOn<string>(from(list));
+
+      expect(SpyUtils.hasSpys()).toBe(true);
+      disconnect();
+      expect(SpyUtils.hasSpys()).toBe(false);
+    });
+
+    it('should cleanup with `disconnect()`', () => {
+      const [, disconnect] = spyOn<string>(from(list));
+
+      expect(SpyUtils.hasSpys()).toBe(true);
+      disconnect();
+      expect(SpyUtils.hasSpys()).toBe(false);
+    });
+  });
+
+  describe('supports globa subscription cleanup without `disconnect()`', () => {
+    afterEach(() => {
+      expect(SpyUtils.hasSpys()).toBe(true);
+      SpyUtils.disposeAll();
+      expect(SpyUtils.hasSpys()).toBe(false);
+    });
+    it('should detect subscriptions', () => {
+      let s2Completed = false;
+      const onCompletion = () => (s2Completed = true);
+
+      spyOn<string>(from(['1st', '2nd', '3rd']));
+      spyOn<string>(from(['4th', '5th', '6th']), onCompletion);
+
+      const isWatching = SpyUtils.hasSpys();
+      expect(isWatching).toBe(true);
+      expect(s2Completed).toBe(true);
+    });
+  });
+
+  describe('spyOn with fakeTime', () => {
+    afterEach(() => SpyUtils.disposeAll());
+
+    it(
+      'should handle delays with a virtual scheduler',
+      fakeTime((flush) => {
+        const VALUES = ['first', 'second', 'third'];
+        const delayed$ = from(VALUES).pipe(delay(20000));
+        const [spy] = spyOn(delayed$);
+
+        flush();
+
+        expect(spy.values).toEqual(VALUES);
+      })
+    );
+
+    it(
+      'should handle `done()` functionality as well',
+      fakeTime((flush, done) => {
+        const VALUES = ['first', 'second', 'third'];
+        const delayed$ = from(VALUES).pipe(delay(20000));
+        const [spy1] = spyOn(delayed$, (spy2: ObserverSpy<string>) => {
+          expect(spy2.values).toEqual(spy1.values);
+          done();
+        });
+
+        flush();
+      })
+    );
+  });
+});

--- a/src/spy-on.ts
+++ b/src/spy-on.ts
@@ -1,0 +1,73 @@
+import { Observer, Observable, Subscription } from 'rxjs';
+import { ObserverSpy, CompletionCallback } from './observer-spy';
+
+/**
+ * Define Tuple reponse from spyOn() calls
+ */
+export type SpyOnResults<T> = [ObserverSpy<T>, () => void, Observable<any>];
+
+/**
+ * !! Internal registry of active spy instances
+ */
+let subscriptions: SpyOnResults<any>[] = [];
+
+/**
+ * Internal util function to remove a spy from the global watch list
+ */
+function removeSpyFromWatchList(target: ObserverSpy<any>) {
+  // Rebuild watch list WITHOUT the target spy instance
+  subscriptions = subscriptions.reduce(
+    (buffer: SpyOnResults<any>[], item: SpyOnResults<any>) => {
+      const [spy] = item;
+      if (target !== spy) {
+        buffer.push(item);
+      }
+      return buffer;
+    },
+    []
+  );
+}
+
+export const SpyUtils = {
+  /**
+   * Freeze all spys and dispose of any subscriptions
+   * Used with tests `afterEach(() => disposeAllSpys())`
+   */
+  disposeAll() {
+    [...subscriptions].map(([spy, dispose]) => {
+      spy.freeze(true);
+      dispose();
+    });
+
+    subscriptions = [];
+  },
+
+  /**
+   * Allows external world to check for existing subscriptions
+   */
+  hasSpys(): boolean {
+    return subscriptions.length > 0;
+  },
+};
+
+/**
+ * spyOn(): simplify use of ObserverSpy by black-box'ing the
+ * ObserverSpy construction and disposal details.
+ *
+ * @param source Observable<T>
+ * @param completionCallback [optional] Callback function invoked when the source stream completes
+ */
+export function spyOn<T>(
+  source$: Observable<T>,
+  completionCallback?: CompletionCallback
+): SpyOnResults<T> {
+  const spy = new ObserverSpy<T>(completionCallback);
+  const subscription = source$.subscribe(spy);
+  const dispose = () => {
+    subscription.unsubscribe();
+    removeSpyFromWatchList(spy);
+  };
+  subscriptions.push([spy, dispose, source$]);
+
+  return [spy, dispose, source$];
+}


### PR DESCRIPTION
Enable developers to easily spy on Observables and supports auto-unsubscribe on all spies:

*  Use `spyOn(<observable>, <completionCallback>)`
*  Use `SpyUtils.disposeAll()` to clean up in `afterEach()` tests

BREAKING CHANGE:

Revised ObserverSpy API with better support for implicit getters and prevention of state mutations. Uses Tuples to return spy instance(s) and information:

```ts
ObserverSpy<T> implements Observer {
  values: T[];                  // implicit getter
  hasValues: boolean;   // implicit getter
  isComplete: boolean; // implicit getter
  state: ObserverState; // implicit getter

  readFirst(): T;
  readLast(): T;
  freeze();
}
```
