### PR TITLE
Return this in expectErrors()

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ it('should spy on Observable errors', () => {
 
   // BTW, this could also be set like this:
   observerSpy.expectErrors(); // <-- ALTERNATIVE WAY TO SET IT
+  // or even like this:
+  observerSpy = new ObserverSpy().expectErrors(); // <-- ALTERNATIVE WAY TO SET IT
 
   fakeObservable.subscribe(observerSpy);
 

--- a/README.md
+++ b/README.md
@@ -341,12 +341,12 @@ it('should spy on Observable errors', () => {
   const fakeObservable = throwError('OOPS');
 
   const observerSpy = new ObserverSpy({expectErrors: true}); // <-- IMPORTANT
+  // OR
+  const observerSpy = new ObserverSpy().expectErrors(); // <-- ALTERNATIVE WAY TO SET IT
 
-  // BTW, this could also be set like this:
+  // Or even...
   observerSpy.expectErrors(); // <-- ALTERNATIVE WAY TO SET IT
-  // or even like this:
-  observerSpy = new ObserverSpy().expectErrors(); // <-- ALTERNATIVE WAY TO SET IT
-
+  
   fakeObservable.subscribe(observerSpy);
 
   expect(observerSpy.receivedError()).toBe(true);

--- a/src/observer-spy.spec.ts
+++ b/src/observer-spy.spec.ts
@@ -147,6 +147,15 @@ describe('ObserverSpy', () => {
       expect(observerSpy.receivedError()).toBe(true);
     });
 
+    it('should know whether it got an "error" notification if "expectErrors" was called', () => {
+      const observerSpy: ObserverSpy<string> = new ObserverSpy<string>().expectErrors();
+      const { throwingObservable } = getThrowingObservable();
+
+      throwingObservable.subscribe(observerSpy).unsubscribe();
+
+      expect(observerSpy.receivedError()).toBe(true);
+    });
+
     it('should return the error object it received if "expectErrors" is configured', () => {
       const observerSpy: ObserverSpy<string> = new ObserverSpy({ expectErrors: true });
       const { throwingObservable } = getThrowingObservable();

--- a/src/observer-spy.ts
+++ b/src/observer-spy.ts
@@ -82,8 +82,9 @@ export class ObserverSpy<T> implements Observer<T> {
     });
   }
 
-  expectErrors() {
+  expectErrors(): this {
     this.state.errorIsExpected = true;
+    return this;
   }
 
   getValuesLength(): number {


### PR DESCRIPTION
Return `this` in `expectErrors()` to enable writing
```js
expect(subscribeSpyTo(observable).expectErrors().getError()).toStrictEqual(error);
```

Closes #46 